### PR TITLE
Prepare for release on pypi.org

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fio_banka"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name = "Petr Beranek", email = "petrberanek.mail@gmail.com" },
 ]


### PR DESCRIPTION
I just discovered it is not possible to erase the initial invalid release (1.0.0) from pypi.org. So I'm bumping the version number to create a new one.