### PR TITLE
ci: fix invalid pkg versioning

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -20,11 +20,8 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pipenv build
-          # Not using `--deploy` here. Updates should be handled by a bot.
-          pipenv install --dev
+          python3 -m pip install --upgrade build
       - name: Build package
-        # The `build` pkg is not installed in the virtualenv.
         run: python3 -m build
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pipenv build
-          # Not using `--deploy` here. Updates should be handled by a bot.
-          pipenv install --dev
+          pipenv sync --dev
       - name: Build package
         # The `build` pkg is not installed in the virtualenv.
         run: python3 -m build


### PR DESCRIPTION
Because of running `pipenv install` instead of `pipenv sync`, pipenv modified Pipfile.lock every time a new version of a dependency was released. This made setuptools_scm to detect a diff in the git repo and produce version like `3.0.1.dev...` instead of expected `3.0.0`. This now should be fixed.